### PR TITLE
Update tmux mouse and add install java from brew cask

### DIFF
--- a/bootcamp.sh
+++ b/bootcamp.sh
@@ -8,12 +8,6 @@ then
   xcode-select --install
 fi
 
-if [ ! $(which javac) ]
-then
-  echo "Install Java JDK"
-  exit
-fi
-
 if [ "$(uname -s)" == "Darwin" ]
 then
   echo "Updating Mac OS X."
@@ -33,6 +27,12 @@ then
   brew tap homebrew/binary
   brew tap homebrew/x11
 
+  brew install \
+    caskroom/cask/brew-cask
+
+  brew cask install \
+    java
+
   # Install homebrew packages
   echo "brew install"
   brew install \
@@ -51,8 +51,7 @@ then
     tmux \
     tree \
     zsh \
-    wget \
-    caskroom/cask/brew-cask
+    wget
 
   # Install homebrew casks
   echo "brew cask install"
@@ -81,7 +80,6 @@ then
   echo "brew install again"
   brew install \
     meld
-
 
   echo "brew update"
   brew update

--- a/tmux.conf
+++ b/tmux.conf
@@ -19,9 +19,13 @@ setw -g automatic-rename on
 set -g history-limit 1000000
 
 # use mouse in copy mode (allows scroll wheel through history)
-setw -g mode-mouse on
+# setw -g mode-mouse on
 # Allow mouse to select which pane to use
-set -g mouse-select-pane on
+# set -g mouse-select-pane on
+# mouse mode
+set -g mouse on
+bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
+bind -n WheelDownPane select-pane -t= \; send-keys -M
 
 # fix shitty MacOSX behavior
 # see https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard


### PR DESCRIPTION
In recent versions of tmux some of the mouse commands were
deprecated.  mouse-blah commands were replace with mouse only
with no upgrade path.  There seems to be a lot of debate over this
poorly executed change.  Also, java is available in brew cask so why
no use it.